### PR TITLE
fix: read codec can be null or miss configured when answer is in pro…

### DIFF
--- a/modules/mod_audio_fork/mod_audio_fork.c
+++ b/modules/mod_audio_fork/mod_audio_fork.c
@@ -79,11 +79,22 @@ static switch_status_t start_capture(switch_core_session_t *session,
 		return SWITCH_STATUS_FALSE;
 	}
 
-	read_codec = switch_core_session_get_read_codec(session);
-
 	if (switch_channel_pre_answer(channel) != SWITCH_STATUS_SUCCESS) {
 		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR, "mod_audio_fork: channel must have reached pre-answer status before calling start!\n");
 		return SWITCH_STATUS_FALSE;
+	}
+
+	read_codec = switch_core_session_get_read_codec(session);
+	if (read_codec == NULL) {
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_WARNING, "No read codec assigned, set default session rate to 8000 samples\n");
+		samples_per_second = 8000;
+	} else {
+		if (read_codec->implementation == NULL) {
+			switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_WARNING, "No read codec implementation assigned, set default session rate to 8000 samples\n");
+			samples_per_second = 8000;
+		} else {
+			samples_per_second = read_codec->implementation->actual_samples_per_second;
+		}
 	}
 
 	switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_DEBUG, "calling fork_session_init.\n");


### PR DESCRIPTION
 read codec can be null or miss configured when answer is in progress