### PR TITLE
Change mod_dialogflow to receive optional parameters for output audio config

### DIFF
--- a/modules/mod_dialogflow/README.md
+++ b/modules/mod_dialogflow/README.md
@@ -42,11 +42,15 @@ To simply use the defaults for both environment and region:
 dialogflow-project-id, i.e myproject
 ```
 
-##### Output Audio Config
 By default, [Output Audio configurations](https://cloud.google.com/dialogflow/es/docs/reference/rest/v2/OutputAudioConfig) will be ignored and the configs selected for [your agent in Dialogflow platform](https://dialogflow.cloud.google.com/) will be used, however if you wish to abstract your implementation from the platform and define them programatically it can be done in the dialogflow_start command as follows:
 
 ```
-dialogflow-project-id:environment:region:speakingRate:pitch:volume:voice-name:voice-gender:effect, i.e myproject:production:eu-west1:1.1:1.5:2.5:en-GB-Standard-D:F:
+dialogflow-project-id:environment:region:speakingRate:pitch:volume:voice-name:voice-gender:effect
+```
+
+Example:
+```
+myproject:production:eu-west1:1.1:1.5:2.5:en-GB-Standard-D:F:handset-class-device
 ```
 Speaking rate, pitch and volume should take the value of a double. Information [here](https://cloud.google.com/dialogflow/es/docs/reference/rest/v2/projects.agent.environments#synthesizespeechconfig).
 

--- a/modules/mod_dialogflow/README.md
+++ b/modules/mod_dialogflow/README.md
@@ -19,7 +19,7 @@ dialogflow_start <uuid> <project-id> <lang-code> [<event>]
 ```
 Attaches media bug to channel and performs streaming recognize request.
 - `uuid` - unique identifier of Freeswitch channel
-- `project-id` - the identifier of the dialogflow project to execute, which may optionally include a dialogflow environment and a region (see below).
+- `project-id` - the identifier of the dialogflow project to execute, which may optionally include a dialogflow environment, a region and output audio configurations (see below).
 - `lang-code` - a valid dialogflow [language tag](https://dialogflow.com/docs/reference/language) to use for speech recognition
 - `event` - name of an initial event to send to dialogflow; e.g. to trigger an initial prompt
 
@@ -42,7 +42,8 @@ To simply use the defaults for both environment and region:
 dialogflow-project-id, i.e myproject
 ```
 
-By default, [Output Audio configurations](https://cloud.google.com/dialogflow/es/docs/reference/rest/v2/OutputAudioConfig) will be ignored and the configs selected for [your agent in Dialogflow platform will be used](https://dialogflow.cloud.google.com/), however if you wish to abstract your implementation from it and define them programatically it can be done in the dialogflow_start command as follows:
+##### Output Audio Config
+By default, [Output Audio configurations](https://cloud.google.com/dialogflow/es/docs/reference/rest/v2/OutputAudioConfig) will be ignored and the configs selected for [your agent in Dialogflow platform](https://dialogflow.cloud.google.com/) will be used, however if you wish to abstract your implementation from the platform and define them programatically it can be done in the dialogflow_start command as follows:
 
 ```
 dialogflow-project-id:environment:region:speakingRate:pitch:volume:voice-name:voice-gender:effect, i.e myproject:production:eu-west1:1.1:1.5:2.5:en-GB-Standard-D:F:

--- a/modules/mod_dialogflow/README.md
+++ b/modules/mod_dialogflow/README.md
@@ -23,7 +23,7 @@ Attaches media bug to channel and performs streaming recognize request.
 - `lang-code` - a valid dialogflow [language tag](https://dialogflow.com/docs/reference/language) to use for speech recognition
 - `event` - name of an initial event to send to dialogflow; e.g. to trigger an initial prompt
 
-When executing a dialogflow project, the environment and region will default to 'draft' and 'us', respectively.  
+When executing a dialogflow project, the environment and region will default to 'draft' and 'us', respectively.
 
 To specify both an environment and a region, provide a value for project-id in the dialogflow_start command as follows:
 ```
@@ -41,6 +41,19 @@ To simply use the defaults for both environment and region:
 ```
 dialogflow-project-id, i.e myproject
 ```
+
+By default, [Output Audio configurations](https://cloud.google.com/dialogflow/es/docs/reference/rest/v2/OutputAudioConfig) will be ignored and the configs selected for [your agent in Dialogflow platform will be used](https://dialogflow.cloud.google.com/), however if you wish to abstract your implementation from it and define them programatically it can be done in the dialogflow_start command as follows:
+
+```
+dialogflow-project-id:environment:region:speakingRate:pitch:volume:voice-name:voice-gender:effect, i.e myproject:production:eu-west1:1.1:1.5:2.5:en-GB-Standard-D:F:
+```
+Speaking rate, pitch and volume should take the value of a double. Information [here](https://cloud.google.com/dialogflow/es/docs/reference/rest/v2/projects.agent.environments#synthesizespeechconfig).
+
+Voice Name should take a valid Text-to-speech model name (choose available voices from https://cloud.google.com/text-to-speech/docs/voices). If not set, the Dialogflow service will choose a voice based on the other parameters such as language code and gender. 
+
+Voice Gender should be M for Male, F for Female, N for neutral gender or leave empty for Unspecified.  If not set, the Dialogflow service will choose a voice based on the other parameters such as language code and name. Note that this is only a preference, not requirement. If a voice of the appropriate gender is not available, the synthesizer should substitute a voice with a different gender rather than failing the request.
+
+Effects are applied on the text-to-speech and are used to improve the playback of an audio on different types of hardware. Available effects and information [here](https://cloud.google.com/text-to-speech/docs/audio-profiles#available_audio_profiles).
 
 #### dialogflow_stop
 ```

--- a/modules/mod_dialogflow/google_glue.cpp
+++ b/modules/mod_dialogflow/google_glue.cpp
@@ -205,7 +205,7 @@ public:
 			audio_config->set_language_code(m_lang.c_str());
 			audio_config->set_single_utterance(true);
         }
-        switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO, "GStreamer::startStream OutputAudioConfig: speaking rate %f, pitch %f, volume %f, voice %s %s, effects %s\n", m_speakingRate, m_pitch, m_volume, m_voiceName, m_voiceGender, m_effects);
+        switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO, "GStreamer::startStream OutputAudioConfig: speaking rate %f, pitch %f, volume %f, voice name '%s' gender '%s', effects '%s'\n", m_speakingRate, m_pitch, m_volume, m_voiceName.c_str(), m_voiceGender.c_str(), m_effects.c_str());
         if (isAnyOutputAudioConfigChanged()) {
             auto* outputAudioConfig = m_request->mutable_output_audio_config();
             outputAudioConfig->set_sample_rate_hertz(16000);

--- a/modules/mod_dialogflow/google_glue.cpp
+++ b/modules/mod_dialogflow/google_glue.cpp
@@ -111,9 +111,9 @@ void tokenize(std::string const &str, const char delim, std::vector<std::string>
 
 class GStreamer {
 public:
-	GStreamer(switch_core_session_t *session, const char* lang, char* projectId, char* event, char* text) : 
-	m_lang(lang), m_sessionId(switch_core_session_get_uuid(session)), m_environment("draft"), m_regionId("us"),
-	m_finished(false), m_packets(0) {
+    GStreamer(switch_core_session_t *session, const char* lang, char* projectId, char* event, char* text) :
+            m_lang(lang), m_sessionId(switch_core_session_get_uuid(session)), m_environment("draft"), m_regionId("us"),
+            m_speakingRate(), m_pitch(), m_volume(), m_voiceName(""), m_voiceGender(""), m_effects(""), m_finished(false), m_packets(0) {
 		const char* var;
 		switch_channel_t* channel = switch_core_session_get_channel(session);
 		std::vector<std::string> tokens;
@@ -124,7 +124,13 @@ public:
 			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "GStreamer: token %d: '%s'\n", idx, s.c_str());
 			if (0 == idx) m_projectId = s;
 			else if (1 == idx && s.length() > 0) m_environment = s;
-			else if (2 == idx && s.length() > 0) m_regionId = s;
+            else if (2 == idx && s.length() > 0) m_regionId = s;
+            else if (3 == idx && s.length() > 0) m_speakingRate = stod(s);
+            else if (4 == idx && s.length() > 0) m_pitch = stod(s);
+            else if (5 == idx && s.length() > 0) m_volume = stod(s);
+            else if (6 == idx && s.length() > 0) m_voiceName = s;
+            else if (7 == idx && s.length() > 0) m_voiceGender = s;
+            else if (8 == idx && s.length() > 0) m_effects = s;
 			idx++;
 		}
 
@@ -198,10 +204,35 @@ public:
 			audio_config->set_audio_encoding(AudioEncoding::AUDIO_ENCODING_LINEAR_16);
 			audio_config->set_language_code(m_lang.c_str());
 			audio_config->set_single_utterance(true);
-		}
+        }
+        switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO, "GStreamer::startStream OutputAudioConfig: speaking rate %f, pitch %f, volume %f, voice %s %s, effects %s\n", m_speakingRate, m_pitch, m_volume, m_voiceName, m_voiceGender, m_effects);
+        if (isAnyOutputAudioConfigChanged()) {
+            auto* outputAudioConfig = m_request->mutable_output_audio_config();
+            outputAudioConfig->set_sample_rate_hertz(16000);
+            outputAudioConfig->set_audio_encoding(OutputAudioEncoding::OUTPUT_AUDIO_ENCODING_LINEAR_16);
 
-  	m_streamer = m_stub->StreamingDetectIntent(m_context.get());
-  	m_streamer->Write(*m_request);
+            auto* synthesizeSpeechConfig = outputAudioConfig->mutable_synthesize_speech_config();
+            if (m_speakingRate) synthesizeSpeechConfig->set_speaking_rate(m_speakingRate);
+            if (m_pitch) synthesizeSpeechConfig->set_pitch(m_pitch);
+            if (m_volume) synthesizeSpeechConfig->set_volume_gain_db(m_volume);
+            if (!m_effects.empty()) synthesizeSpeechConfig->add_effects_profile_id(m_effects);
+
+            auto* voice = synthesizeSpeechConfig->mutable_voice();
+            if (!m_voiceName.empty()) voice->set_name(m_voiceName);
+            if (!m_voiceGender.empty()) {
+                SsmlVoiceGender gender = SsmlVoiceGender::SSML_VOICE_GENDER_UNSPECIFIED;
+                switch (toupper(m_voiceGender[0]))
+                {
+                    case 'F': gender = SsmlVoiceGender::SSML_VOICE_GENDER_MALE; break;
+                    case 'M': gender = SsmlVoiceGender::SSML_VOICE_GENDER_FEMALE; break;
+                    case 'N': gender = SsmlVoiceGender::SSML_VOICE_GENDER_NEUTRAL; break;
+                }
+                voice->set_ssml_gender(gender);
+            }
+        }
+
+		m_streamer = m_stub->StreamingDetectIntent(m_context.get());
+		m_streamer->Write(*m_request);
 	}
 	bool write(void* data, uint32_t datalen) {
 		if (m_finished) {
@@ -237,6 +268,10 @@ public:
 		return m_finished;
 	}
 
+    bool isAnyOutputAudioConfigChanged() {
+        return m_speakingRate|| m_pitch || m_volume || !m_voiceName.empty() || !m_voiceGender.empty();
+    }
+
 private:
 	std::string m_sessionId;
 	std::shared_ptr<grpc::ClientContext> m_context;
@@ -246,8 +281,14 @@ private:
 	std::shared_ptr<StreamingDetectIntentRequest> m_request;
 	std::string m_lang;
 	std::string m_projectId;
-	std::string m_environment;
-	std::string m_regionId;
+    std::string m_environment;
+    std::string m_regionId;
+    double m_speakingRate;
+    double m_pitch;
+    double m_volume;
+    std::string m_effects;
+    std::string m_voiceName;
+    std::string m_voiceGender;
 	bool m_finished;
 	uint32_t m_packets;
 };

--- a/modules/mod_dialogflow/google_glue.cpp
+++ b/modules/mod_dialogflow/google_glue.cpp
@@ -205,8 +205,9 @@ public:
 			audio_config->set_language_code(m_lang.c_str());
 			audio_config->set_single_utterance(true);
         }
-        switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO, "GStreamer::startStream OutputAudioConfig: speaking rate %f, pitch %f, volume %f, voice name '%s' gender '%s', effects '%s'\n", m_speakingRate, m_pitch, m_volume, m_voiceName.c_str(), m_voiceGender.c_str(), m_effects.c_str());
+        switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "GStreamer::startStream checking OutputAudioConfig custom parameters: speaking rate %f, pitch %f, volume %f, voice name '%s' gender '%s', effects '%s'\n", m_speakingRate, m_pitch, m_volume, m_voiceName.c_str(), m_voiceGender.c_str(), m_effects.c_str());
         if (isAnyOutputAudioConfigChanged()) {
+	        switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO, "GStreamer::startStream adding a custom OutputAudioConfig to the request since at least one parameter was received.");
             auto* outputAudioConfig = m_request->mutable_output_audio_config();
             outputAudioConfig->set_sample_rate_hertz(16000);
             outputAudioConfig->set_audio_encoding(OutputAudioEncoding::OUTPUT_AUDIO_ENCODING_LINEAR_16);
@@ -229,7 +230,9 @@ public:
                 }
                 voice->set_ssml_gender(gender);
             }
-        }
+        } else {
+			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO, "GStreamer::startStream no custom parameters for OutputAudioConfig, keeping default");
+		}
 
 		m_streamer = m_stub->StreamingDetectIntent(m_context.get());
 		m_streamer->Write(*m_request);
@@ -269,7 +272,7 @@ public:
 	}
 
     bool isAnyOutputAudioConfigChanged() {
-        return m_speakingRate|| m_pitch || m_volume || !m_voiceName.empty() || !m_voiceGender.empty();
+        return m_speakingRate|| m_pitch || m_volume || !m_voiceName.empty() || !m_voiceGender.empty() || !m_effects.empty();
     }
 
 private:

--- a/modules/mod_dialogflow/google_glue.cpp
+++ b/modules/mod_dialogflow/google_glue.cpp
@@ -124,13 +124,13 @@ public:
 			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "GStreamer: token %d: '%s'\n", idx, s.c_str());
 			if (0 == idx) m_projectId = s;
 			else if (1 == idx && s.length() > 0) m_environment = s;
-            else if (2 == idx && s.length() > 0) m_regionId = s;
-            else if (3 == idx && s.length() > 0) m_speakingRate = stod(s);
-            else if (4 == idx && s.length() > 0) m_pitch = stod(s);
-            else if (5 == idx && s.length() > 0) m_volume = stod(s);
-            else if (6 == idx && s.length() > 0) m_voiceName = s;
-            else if (7 == idx && s.length() > 0) m_voiceGender = s;
-            else if (8 == idx && s.length() > 0) m_effects = s;
+			else if (2 == idx && s.length() > 0) m_regionId = s;
+			else if (3 == idx && s.length() > 0) m_speakingRate = stod(s);
+			else if (4 == idx && s.length() > 0) m_pitch = stod(s);
+			else if (5 == idx && s.length() > 0) m_volume = stod(s);
+			else if (6 == idx && s.length() > 0) m_voiceName = s;
+			else if (7 == idx && s.length() > 0) m_voiceGender = s;
+			else if (8 == idx && s.length() > 0) m_effects = s;
 			idx++;
 		}
 
@@ -284,14 +284,14 @@ private:
 	std::shared_ptr<StreamingDetectIntentRequest> m_request;
 	std::string m_lang;
 	std::string m_projectId;
-    std::string m_environment;
-    std::string m_regionId;
-    double m_speakingRate;
-    double m_pitch;
-    double m_volume;
-    std::string m_effects;
-    std::string m_voiceName;
-    std::string m_voiceGender;
+	std::string m_environment;
+	std::string m_regionId;
+	double m_speakingRate;
+	double m_pitch;
+	double m_volume;
+	std::string m_effects;
+	std::string m_voiceName;
+	std::string m_voiceGender;
 	bool m_finished;
 	uint32_t m_packets;
 };


### PR DESCRIPTION
# Description
## Why
- The project I'm working on is using mod_dialogflow in the infrastructure of FreeSWITCH + Drachtio Server + a Drachtio App.
- The goal at the moment is to abstract ourselves from using Dialogflow's platform as much as possible and we have automated most steps, however one issue we were having is that we would always have to go to each Agent/Flow 's page to enable TTS and optionally configure the output audio (in the Speech tab of https://dialogflow.cloud.google.com/#/editAgent/<projectId/ ).

## What
- By sending the OutputAudioConfig ( https://cloud.google.com/dialogflow/es/docs/reference/rpc/google.cloud.dialogflow.v2beta1#google.cloud.dialogflow.v2beta1.OutputAudioConfig ) parameter explicitly in the Streaming Detect Intent Request, the TTS is enabled without needing to do it on the Dialogflow platform page manually
- If ANY parameter related to OutputAudioConfig is sent on the dialogflow_start command it will overwrite the manual configuration with this per-request configuration.


# Tests
- Tested with usages of "dialogflow_start" where the new fields were ignored to guarantee retro compatibility
  - project-id of `dialogflow-project-id:environment:region` for example still works  
- Tested with a flow/agent that had TTS disabled in Dialogflow's platform page 
  - project-id of `dialogflow-project-id:environment:region:speakingRate:pitch:volume:voice-name:voice-gender:effect`

Observations
- Our goal was for this to not be a breaking change
- This implementation is a bit focused in our use case and parameterizing so many details like this may be confusing to new people who try to use mod_dialogflow, so if you believe it doesn't make sense to merge this into the main fork I completely understand and we will be maintaining our separate fork
- It is possible in the future we add more parameters such as sentiment analysis ( https://github.com/drachtio/drachtio-freeswitch-modules/issues/85 ) if my team considers the effort to be justified but, again, it might add even more complexity to this repo