### PR TITLE
Fix buffer overflow in SimpleBuffer

### DIFF
--- a/modules/mod_google_transcribe/simple_buffer.h
+++ b/modules/mod_google_transcribe/simple_buffer.h
@@ -19,7 +19,8 @@ class SimpleBuffer {
       if (datalen % m_chunkSize != 0) return;
       int numChunks = datalen / m_chunkSize;
       for (int i = 0; i < numChunks; i++) {
-        memcpy(m_pNextWrite, data, datalen);
+        memcpy(m_pNextWrite, data, m_chunkSize);
+        data = static_cast<char*>(data) + m_chunkSize;
         if (numItems < m_numChunks) numItems++;
 
         uint32_t offset = (m_pNextWrite - m_pData) / m_chunkSize;


### PR DESCRIPTION
Hi, we are planning to use the google transcribe module and are in the process of reviewing the code. One thing that I've found is a potential buffer overflow in the SimpleBuffer. May be you can take a look.

