### PR TITLE
deepgram: default to general model for languages other than us

### DIFF
--- a/modules/mod_deepgram_transcribe/dg_transcribe_glue.cpp
+++ b/modules/mod_deepgram_transcribe/dg_transcribe_glue.cpp
@@ -97,8 +97,11 @@ namespace {
 
     oss << "/v1/listen?model=";
 
-    // default to conversationai model but allow override
-    if (!model && !customModel) oss << "conversationalai";
+    // default to conversationai model for english, general for others (but allow override)
+    if (!model && !customModel) {
+      if (strncmp(language, "en", 2) == 0) oss << "conversationalai";
+      else oss << "general";
+    }
     else if (customModel) oss << customModel;
     else if (model) oss << model;
 


### PR DESCRIPTION
the conversationalai model is currently on supported for en-us, so for other languages we need to default to the general model