### PR TITLE
fix mod_audio_fork open ws when fs bug already initiated

### DIFF
--- a/modules/mod_audio_fork/lws_glue.cpp
+++ b/modules/mod_audio_fork/lws_glue.cpp
@@ -161,6 +161,8 @@ namespace {
     if (session) {
       switch_channel_t *channel = switch_core_session_get_channel(session);
       switch_media_bug_t *bug = (switch_media_bug_t*) switch_channel_get_private(channel, bugname);
+      switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO, "xhoaluu\n");
+      switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO, event);
       if (bug) {
         private_t* tech_pvt = (private_t*) switch_core_media_bug_get_user_data(bug);
         if (tech_pvt) {
@@ -416,8 +418,12 @@ extern "C" {
     }
 
     *ppUserData = tech_pvt;
+    return SWITCH_STATUS_SUCCESS;
+  }
 
-    AudioPipe *pAudioPipe = static_cast<AudioPipe *>(tech_pvt->pAudioPipe);
+   switch_status_t fork_session_connect(void **ppUserData) {
+    private_t *tech_pvt = static_cast<private_t *>(*ppUserData);
+    AudioPipe *pAudioPipe = static_cast<AudioPipe*>(tech_pvt->pAudioPipe);
     pAudioPipe->connect();
     return SWITCH_STATUS_SUCCESS;
   }

--- a/modules/mod_audio_fork/lws_glue.h
+++ b/modules/mod_audio_fork/lws_glue.h
@@ -16,4 +16,5 @@ switch_status_t fork_session_graceful_shutdown(switch_core_session_t *session, c
 switch_status_t fork_session_send_text(switch_core_session_t *session, char *bugname, char* text);
 switch_bool_t fork_frame(switch_core_session_t *session, switch_media_bug_t *bug);
 switch_status_t fork_service_threads();
+switch_status_t fork_session_connect(void **ppUserData)
 #endif

--- a/modules/mod_audio_fork/mod_audio_fork.c
+++ b/modules/mod_audio_fork/mod_audio_fork.c
@@ -99,6 +99,11 @@ static switch_status_t start_capture(switch_core_session_t *session,
 	switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_DEBUG, "setting bug private data %s.\n", bugname);
 	switch_channel_set_private(channel, bugname, bug);
 
+	if (fork_session_connect(&pUserData) != SWITCH_STATUS_SUCCESS) {
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR, "Error mod_audio_fork session cannot connect.\n");
+		return SWITCH_STATUS_FALSE;
+	}
+
 	switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_DEBUG, "exiting start_capture.\n");
 	return SWITCH_STATUS_SUCCESS;
 }


### PR DESCRIPTION
There is race condition that the mod_audio_fork successfully opened ws connection to the destination so quick that the freeswitch bug name has not been finished add to private data yet. that causing metadata cannot be sent to the ws server.