### PR TITLE
Make sample rate configurable and correct array indexing problem

### DIFF
--- a/modules/mod_google_transcribe/google_glue.cpp
+++ b/modules/mod_google_transcribe/google_glue.cpp
@@ -65,6 +65,7 @@ public:
     uint32_t channels, 
     char* lang, 
     int interim, 
+    uint32_t config_sample_rate,
 		uint32_t samples_per_second,
     int single_utterance, 
     int separate_recognition,
@@ -109,7 +110,7 @@ public:
 		config->set_language_code(lang);
     switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(m_session), SWITCH_LOG_DEBUG, "transcribe language %s \n", lang);
     
-  	config->set_sample_rate_hertz(8000);
+  	config->set_sample_rate_hertz(config_sample_rate);
 
 		config->set_encoding(RecognitionConfig::LINEAR16);
 
@@ -526,8 +527,8 @@ extern "C" {
       return SWITCH_STATUS_SUCCESS;
     }
     switch_status_t google_speech_session_init(switch_core_session_t *session, responseHandler_t responseHandler, 
-          uint32_t samples_per_second, uint32_t channels, char* lang, int interim, char *bugname, int single_utterance,
-          int separate_recognition, int max_alternatives, int profanity_filter, int word_time_offset,
+          uint32_t to_rate, uint32_t samples_per_second, uint32_t channels, char* lang, int interim, char *bugname,
+          int single_utterance, int separate_recognition, int max_alternatives, int profanity_filter, int word_time_offset,
           int punctuation, const char* model, int enhanced, const char* hints, char* play_file, void **ppUserData) {
 
       switch_channel_t *channel = switch_core_session_get_channel(session);
@@ -546,8 +547,8 @@ extern "C" {
       }
       
       switch_mutex_init(&cb->mutex, SWITCH_MUTEX_NESTED, switch_core_session_get_pool(session));
-      if (sampleRate != 8000) {
-          cb->resampler = speex_resampler_init(channels, sampleRate, 8000, SWITCH_RESAMPLE_QUALITY, &err);
+      if (sampleRate != to_rate) {
+          cb->resampler = speex_resampler_init(channels, sampleRate, to_rate, SWITCH_RESAMPLE_QUALITY, &err);
         if (0 != err) {
            switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR, "%s: Error initializing resampler: %s.\n",
                                  switch_channel_get_name(channel), speex_resampler_strerror(err));
@@ -589,7 +590,7 @@ extern "C" {
 
       GStreamer *streamer = NULL;
       try {
-        streamer = new GStreamer(session, channels, lang, interim, sampleRate, single_utterance, separate_recognition, max_alternatives,
+        streamer = new GStreamer(session, channels, lang, interim, to_rate, sampleRate, single_utterance, separate_recognition, max_alternatives,
          profanity_filter, word_time_offset, punctuation, model, enhanced, hints);
         cb->streamer = streamer;
       } catch (std::exception& e) {

--- a/modules/mod_google_transcribe/google_glue.h
+++ b/modules/mod_google_transcribe/google_glue.h
@@ -4,8 +4,8 @@
 switch_status_t google_speech_init();
 switch_status_t google_speech_cleanup();
 switch_status_t google_speech_session_init(switch_core_session_t *session, responseHandler_t responseHandler, 
-		uint32_t samples_per_second, uint32_t channels, char* lang, int interim, char *bugname, int single_utterence, int separate_recognition,
-		int max_alternatives, int profinity_filter, int word_time_offset, int punctuation, const char* model, int enhanced, 
+		uint32_t to_rate, uint32_t samples_per_second, uint32_t channels, char* lang, int interim, char *bugname, int single_utterence,
+		int separate_recognition, int max_alternatives, int profinity_filter, int word_time_offset, int punctuation, const char* model, int enhanced, 
 		const char* hints, char* play_file, void **ppUserData);
 switch_status_t google_speech_session_cleanup(switch_core_session_t *session, int channelIsClosing, switch_media_bug_t *bug);
 switch_bool_t google_speech_frame(switch_media_bug_t *bug, void* user_data);

--- a/modules/mod_google_transcribe/mod_google_transcribe.c
+++ b/modules/mod_google_transcribe/mod_google_transcribe.c
@@ -301,10 +301,10 @@ SWITCH_STANDARD_API(transcribe2_function)
 	}
 
 	if (zstr(cmd) || 
-      (!strcasecmp(argv[1], "stop") && argc < 2) ||
-      (!strcasecmp(argv[1], "start") && argc < 9) ||
+      (argc < 2) ||
+      (!strcasecmp(argv[1], "start") && argc < 10) ||
       zstr(argv[0])) {
-		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR, "Error with command %s %s %s.\n", cmd, argv[0], argv[1]);
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR, "Error with command %s %s.\n", cmd, argv[0]);
 		stream->write_function(stream, "-USAGE: %s\n", TRANSCRIBE2_API_SYNTAX);
 		goto done;
 	} else {
@@ -326,7 +326,7 @@ SWITCH_STANDARD_API(transcribe2_function)
 				if (argc > 10) {
 					sample_rate = atol(argv[10]);
 				}
-				if (argc > 11){
+				if (argc > 12){
 					model = argv[11]; // model 
 					enhanced = !strcmp(argv[12], "true"); // enhanced
 				}

--- a/modules/mod_google_transcribe/mod_google_transcribe.c
+++ b/modules/mod_google_transcribe/mod_google_transcribe.c
@@ -8,6 +8,8 @@
 #include <stdlib.h>
 #include <switch.h>
 
+static const uint32_t DEFAULT_SAMPLE_RATE = 8000;
+
 /* Prototypes */
 SWITCH_MODULE_SHUTDOWN_FUNCTION(mod_transcribe_shutdown);
 SWITCH_MODULE_RUNTIME_FUNCTION(mod_transcribe_runtime);
@@ -150,7 +152,7 @@ static switch_status_t do_stop(switch_core_session_t *session, char *bugname)
 }
 
 static switch_status_t start_capture2(switch_core_session_t *session, switch_media_bug_flag_t flags, 
-  char* lang, int interim, int single_utterance, int separate_recognition, int max_alternatives,
+  uint32_t sample_rate, char* lang, int interim, int single_utterance, int separate_recognition, int max_alternatives,
   int profinity_filter, int word_time_offset, int punctuation, const char* model, int enhanced, const char* hints, char* play_file)
 {
 	switch_channel_t *channel = switch_core_session_get_channel(session);
@@ -174,7 +176,7 @@ static switch_status_t start_capture2(switch_core_session_t *session, switch_med
 
 	samples_per_second = !strcasecmp(read_impl.iananame, "g722") ? read_impl.actual_samples_per_second : read_impl.samples_per_second;
 
-	if (SWITCH_STATUS_FALSE == google_speech_session_init(session, responseHandler, samples_per_second, flags & SMBF_STEREO ? 2 : 1, lang, interim, MY_BUG_NAME, single_utterance,
+	if (SWITCH_STATUS_FALSE == google_speech_session_init(session, responseHandler, sample_rate, samples_per_second, flags & SMBF_STEREO ? 2 : 1, lang, interim, MY_BUG_NAME, single_utterance,
 	 separate_recognition, max_alternatives, profinity_filter, word_time_offset, punctuation, model, enhanced, hints, play_file, &pUserData)) {
 		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Error initializing google speech session.\n");
 		return SWITCH_STATUS_FALSE;
@@ -265,7 +267,7 @@ static switch_status_t start_capture(switch_core_session_t *session, switch_medi
 
 	samples_per_second = !strcasecmp(read_impl.iananame, "g722") ? read_impl.actual_samples_per_second : read_impl.samples_per_second;
 
-	if (SWITCH_STATUS_FALSE == google_speech_session_init(session, responseHandler, samples_per_second, flags & SMBF_STEREO ? 2 : 1, lang, interim, bugname, single_utterance,
+	if (SWITCH_STATUS_FALSE == google_speech_session_init(session, responseHandler, DEFAULT_SAMPLE_RATE, samples_per_second, flags & SMBF_STEREO ? 2 : 1, lang, interim, bugname, single_utterance,
 	 separate_recognition, max_alternatives, profanity_filter, word_time_offset, punctuation, model, enhanced, hints, NULL, &pUserData)) {
 		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Error initializing google speech session.\n");
 		return SWITCH_STATUS_FALSE;
@@ -281,11 +283,12 @@ static switch_status_t start_capture(switch_core_session_t *session, switch_medi
 }
 
 // #define TRANSCRIBE_API_SYNTAX "<uuid> [start|stop] [lang-code] [interim] [single-utterance](bool) [seperate-recognition](bool) [max-alternatives](int) [profinity-filter](bool) [word-time](bool) [punctuation](bool) [model](string) [enhanced](true) [hints](string without space) [play-file]"
-#define TRANSCRIBE2_API_SYNTAX "<uuid> [start|stop] [lang-code] [interim]  [single-utterance] [seperate-recognition] [max-alternatives] [profinity-filter] [word-time] [punctuation] [model] [enhanced] [hints] [play-file]"
+#define TRANSCRIBE2_API_SYNTAX "<uuid> [start|stop] [lang-code] [interim]  [single-utterance] [seperate-recognition] [max-alternatives] [profinity-filter] [word-time] [punctuation] [sample-rate] [model] [enhanced] [hints] [play-file]"
 SWITCH_STANDARD_API(transcribe2_function)
 {
 	char *mycmd = NULL, *argv[20] = { 0 };
 	int argc = 0, enhanced = 0;
+	uint32_t sample_rate = DEFAULT_SAMPLE_RATE;
 	const char* hints = NULL;
 	const char* model = NULL;
 	char* play_file = NULL;
@@ -320,18 +323,21 @@ SWITCH_STANDARD_API(transcribe2_function)
 				int profinity_filter = !strcmp(argv[7], "true"); // profinity-filter
 				int word_time_offset = !strcmp(argv[8], "true"); // word-time
 				int punctuation      = !strcmp(argv[9], "true");  //punctuation
-				if (argc > 9){
-					model = argv[10]; // model 
-					enhanced = !strcmp(argv[11], "true"); // enhanced
+				if (argc > 10) {
+					sample_rate = atol(argv[10]);
 				}
 				if (argc > 11){
-					hints = argv[12]; // hints
+					model = argv[11]; // model 
+					enhanced = !strcmp(argv[12], "true"); // enhanced
 				}
-				if (argc > 12){
-					play_file = argv[13];
+				if (argc > 13){
+					hints = argv[13]; // hints
+				}
+				if (argc > 14){
+					play_file = argv[14];
 				}
     		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO, "start transcribing %s %s\n", lang, interim ? "interim": "complete");
-				status = start_capture2(lsession, flags, lang, interim, single_utterance, separate_recognition,max_alternatives,
+				status = start_capture2(lsession, flags, sample_rate, lang, interim, single_utterance, separate_recognition,max_alternatives,
 				profinity_filter, word_time_offset, punctuation, model, enhanced, hints, play_file);
 			}
 			switch_core_session_rwunlock(lsession);


### PR DESCRIPTION
This PR replaces #125 and addresses the issues #150 and #151 . The change to make the sample rate configurable retains the default value at 8000 Hertz so if the parameter is not provided the behaviour will not change.